### PR TITLE
added ability to enable custom compiler flags

### DIFF
--- a/ifs/app/components/Tool/buildTool.js
+++ b/ifs/app/components/Tool/buildTool.js
@@ -97,7 +97,8 @@ function parseFormSelection( formData ) {
                 var r = {};
                 r['name'] = key;
                 r['value'] = value;
-                tool.options.push( r );
+                if (r['value'])
+                    tool.options.push(r);
             }
         }
     });

--- a/ifs/app/components/Tool/toolInput.pug
+++ b/ifs/app/components/Tool/toolInput.pug
@@ -8,7 +8,7 @@ div(ng-if="option.type == 'text'")
     label(for="{{ option.name }}").uk-form-label.text-normal
         | {{ option.displayName }}
     div.uk-form-controls
-        input(type="text" name="{{option.name}}" id="{{option.name}}" value="{{option.prefValue}}").uk-input
+        input(type="text" name="{{option.name}}" id="{{option.name}}" placeholder="{{option.placeholder}}" value="{{option.prefValue}}").uk-input
 
 // file input
 div(ng-if="option.type == 'file'")

--- a/ifs/app/components/Tool/toolRoutes.js
+++ b/ifs/app/components/Tool/toolRoutes.js
@@ -40,7 +40,7 @@ module.exports = function(app) {
                     if( r ){
                         if(r.type == "checkbox")
                             r['prefValue'] = toolPreferences[i].toolValue == "on";
-                        else if(r.type == "select")
+                        else if(r.type == "select" || r.type == "text")
                             r['prefValue'] = toolPreferences[i].toolValue;
                     }
                 }

--- a/ifs/tools/programmingTools/c_tools/programmingParser.py
+++ b/ifs/tools/programmingTools/c_tools/programmingParser.py
@@ -69,7 +69,6 @@ def getProcessInfo( cmd, outFile, errorFile ):
 # Each format has a specific character split sequence such as '##' or ':'
 # Types specify how to tag the incoming sections
 def parse( text, options ):
-
     results = []
     types = options['splitTypes']
     for line in text.splitlines():
@@ -122,7 +121,6 @@ def getKV( dict, key ):
 
 
 def createCmd( options ):
-
     iDir = os.path.normpath( os.path.join( options['dir'], options['includeDir']) )
     srcDir = os.path.normpath( os.path.join(options['dir'], options['srcDir']) )
     # Assumption here that we can still try directory for .h and .c files at the top level
@@ -216,7 +214,8 @@ def main(argv):
         elif opt in ('--errorLevel', '-e'):
             options['errorLevel'] = arg
         elif opt in ('--flags=', '-f'):
-            options['flags'].append(arg)
+            if arg.startswith('-'): # safeguard against malformed flags
+                options['flags'].append(arg)
         elif opt in ('--std=', '-s'):
             options['std'] = arg
         elif opt in ('--suppress', '-u'):

--- a/ifs/tools/toolListProgramming.json
+++ b/ifs/tools/toolListProgramming.json
@@ -21,7 +21,7 @@
                     "displayName": "Language standard (std)",
                     "type": "select",
                     "name": "opt-gccLanguageStd",
-                    "values": [ "c89", "c99","c11"],
+                    "values": [ "c99","c11","c89"],
                     "arg": "-s",
                     "params": ""
                 },
@@ -88,7 +88,7 @@
                     "displayName": "Language standard (std)",
                     "type": "select",
                     "name": "opt-clangLanguageStd",
-                    "values": [ "c89", "c99","c11"],
+                    "values": [ "c99","c11","c89"],
                     "arg": "-s",
                     "params": ""
                 },
@@ -163,7 +163,7 @@
                     "displayName": "CppCheck language standard (std)",
                     "type": "select",
                     "name": "opt-cppCheckLanguageStd",
-                    "values": [ "c89", "c99","c11"],
+                    "values": [ "c99","c11","c89"],
                     "arg": "-s",
                     "params": ""
                 },

--- a/ifs/tools/toolListProgramming.json
+++ b/ifs/tools/toolListProgramming.json
@@ -26,6 +26,14 @@
                     "params": ""
                 },
                 {
+                    "displayName": "Custom compiler flags",
+                    "type": "text",
+                    "name": "opt-gccCompilerFlags",
+                    "placeholder": "ex. -lm -lncurses -DX_OPENSOURCE",
+                    "values": "",
+                    "arg": "-f"
+                },
+                {
                     "displayName": "Standard warnings (-Wall)",
                     "type": "checkbox",
                     "name": "opt-gccLanguageWarningAll",
@@ -83,6 +91,14 @@
                     "values": [ "c89", "c99","c11"],
                     "arg": "-s",
                     "params": ""
+                },
+                {
+                    "displayName": "Custom compiler flags",
+                    "type": "text",
+                    "name": "opt-clangCompilerFlags",
+                    "placeholder": "ex. -lm -lncurses, -D_XOPENSOURCE",
+                    "values": "",
+                    "arg": "-f"
                 },
                 {
                     "displayName": "Standard warnings (-Wall)",


### PR DESCRIPTION
This commit allows tools to define arbitrary text inputs as options;
simple safeguards had to be added in `buildTool.js` and `programmingParser.py` to:

 1. skip empty text arguments without crashing (`buildTool.js`)
 2. handle possibly malformed compilation flags, such as those which do
    not begin with '-' character (`programmingParser.js`)

Testing should be done before this branch is merged to master, but it would nice to have this merged this weekend.