### PR TITLE
various fixes for spell-checker

### DIFF
--- a/ifs/tools/toolList.json
+++ b/ifs/tools/toolList.json
@@ -14,7 +14,7 @@
             "route": "",
             "filesAllowed": "singleFile",
             "parseCmd": "",
-            "defaultArg": "",
+            "defaultArg": "-d 256",
             "fileArgs": "-i",
             "options" : [
                 {


### PR DESCRIPTION
 * fixed error on python 3.4+ where an attempt to call x.decode on line 82 failed; this decode operation was removed as it appears unnecessary
 * added new command-line option to limit the number of feedback items
   returned by the tool
   - this number is arbitrarily set to 256 in the toolList.json file, but can be changed; I added this optional limitation because I noticed large quantities of feedback items significantly slow down processing